### PR TITLE
Updated graphql version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
-# graphql-nodejs
+# GraphQL-MongoDB Server
 
-GraphQL route in nodeJS using express
+GraphQL server in Node.js using Express, MongoDB and Mongoose.
+
+## Requirements
+
+* [Node.js](http://nodejs.org/)
+* [MongoDB](https://www.mongodb.org/) 
+
+## License
+
+The MIT License (MIT) Copyright (c)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/graphql/queries/blog-post/mutiple.js
+++ b/graphql/queries/blog-post/mutiple.js
@@ -9,7 +9,7 @@ import BlogPostModel from '../../../models/blog-post';
 export default {
   type: new GraphQLList(blogPostType),
   args: {},
-  resolve (root, params, options) {
+  resolve (root, params, ctx, options) {
     const projection = getProjection(options.fieldASTs[0]);
 
     return BlogPostModel

--- a/graphql/queries/blog-post/single.js
+++ b/graphql/queries/blog-post/single.js
@@ -17,7 +17,7 @@ export default {
       type: new GraphQLNonNull(GraphQLID)
     }
   },
-  resolve (root, params, options) {
+  resolve (root, params, ctx, options) {
     const projection = getProjection(options.fieldASTs[0]);
 
     return BlogPostModel

--- a/graphql/queries/comment/mutiple.js
+++ b/graphql/queries/comment/mutiple.js
@@ -16,7 +16,7 @@ export default {
       type: new GraphQLNonNull(GraphQLID)
     }
   },
-  resolve (root, params, options) {
+  resolve (root, params, ctx, options) {
     const projection = getProjection(options.fieldASTs[0]);
 
     return CommentModel

--- a/graphql/queries/comment/single.js
+++ b/graphql/queries/comment/single.js
@@ -17,7 +17,7 @@ export default {
       type: new GraphQLNonNull(GraphQLID)
     }
   },
-  resolve (root, params, options) {
+  resolve (root, params, ctx, options) {
     const projection = getProjection(options.fieldASTs[0]);
 
     return CommentModel

--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
-require('babel/register');
+require('babel-core/register');
 require('./app');

--- a/package.json
+++ b/package.json
@@ -1,20 +1,20 @@
 {
-  "name": "graphqlnode",
-  "version": "0.0.0",
-  "description": "Introduction to GraphQL in nodeJS",
-  "license": "GPL",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/bruno12mota/graphql-nodejs"
-  },
-  "scripts": {
-    "start": "node index.js"
-  },
-  "dependencies": {
-    "babel": "^5.8.23",
-    "express": "^4.13.3",
-    "express-graphql": "^0.4.5",
-    "graphql": "^0.4.14",
-    "mongoose": "^4.3.5"
-  }
+    "name": "graphqlnode",
+    "version": "0.0.0",
+    "description": "Introduction to GraphQL in nodeJS",
+    "license": "GPL",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/bruno12mota/graphql-nodejs"
+    },
+    "scripts": {
+        "start": "node index.js"
+    },
+    "dependencies": {
+        "babel": "^5.8.23",
+        "express": "^4.13.3",
+        "express-graphql": "^0.5.4",
+        "graphql": "^0.7.0",
+        "mongoose": "^4.3.5"
+    }
 }


### PR DESCRIPTION
Noticed that the functions resolving the queries (mutations still work) stopped working if you updated the version of graphql. Thought this would be a good update for anyone who is trying to incorporate this tutorial in a newly installed stack.

Changes made based on this [Stackoverflow](https://github.com/graphql/graphql-js/issues/473).
